### PR TITLE
Add Chromium prebuilt and fixup device specific OUT dir [1/2]

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1704,6 +1704,14 @@ SLIM_TARGET_PACKAGE := $(PRODUCT_OUT)/$(SLIM_MOD_VERSION).zip
 
 .PHONY: otapackage bacon bootzip
 otapackage: $(INTERNAL_OTA_PACKAGE_TARGET)
+
+ifeq ($(USE_PREBUILT_CHROMIUM),1)
+ifneq ($(PRODUCT_PREBUILT_WEBVIEWCHROMIUM),yes)
+	@echo "Running Chromium prebuilt setup script..."
+	$(hide) . $(TOPDIR)vendor/slim/tools/chromium_prebuilt.sh $(TOP)
+endif
+endif
+
 bacon: otapackage
 	$(hide) ln -f $(INTERNAL_OTA_PACKAGE_TARGET) $(SLIM_TARGET_PACKAGE)
 	$(hide) $(MD5SUM) $(SLIM_TARGET_PACKAGE) > $(SLIM_TARGET_PACKAGE).md5sum

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -650,10 +650,18 @@ function lunch()
 
     echo
 
+    if [[ $USE_PREBUILT_CHROMIUM -eq 1 ]]; then
+        chromium_prebuilt
+    else
+        # Unset flag in case user opts out later on
+        export PRODUCT_PREBUILT_WEBVIEWCHROMIUM=""
+    fi
+
     fixup_common_out_dir
 
     set_stuff_for_environment
     printconfig
+
 }
 
 # Tab completion for lunch.
@@ -2240,6 +2248,26 @@ function pez {
     return $retval
 }
 
+function chromium_prebuilt() {
+    T=$(gettop)
+    export TARGET_DEVICE=$(get_build_var TARGET_DEVICE)
+    hash=$T/prebuilts/chromium/$TARGET_DEVICE/hash.txt
+    libsCheck=$T/prebuilts/chromium/$TARGET_DEVICE/lib/libwebviewchromium.so
+    appCheck=$T/prebuilts/chromium/$TARGET_DEVICE/app/webview
+    device_target=$T/prebuilts/chromium/$TARGET_DEVICE/
+
+    if [ -r $hash ] && [ $(git --git-dir=$T/external/chromium_org/.git --work-tree=$T/external/chromium_org rev-parse --verify HEAD) == $(cat $hash) ] && [ -f $libsCheck ] && [ -d $appCheck ]; then
+        export PRODUCT_PREBUILT_WEBVIEWCHROMIUM=yes
+        echo "** Prebuilt Chromium is up-to-date; Will be used for build **"
+    else
+        export PRODUCT_PREBUILT_WEBVIEWCHROMIUM=no
+        rm -rfv $device_target
+        echo ""
+        echo "** Prebuilt Chromium out-of-date/not found; Will build from source **"
+        echo ""
+    fi
+}
+
 function get_make_command()
 {
   echo command make
@@ -2277,8 +2305,6 @@ function make()
 {
     mk_timer $(get_make_command) "$@"
 }
-
-
 
 if [ "x$SHELL" != "x/bin/bash" ]; then
     case `ps -o command -p $$` in


### PR DESCRIPTION
IMPORTANT!!
Remember to run before building:
export USE_PREBUILT_CHROMIUM=1
export ANDROID_FIXUP_COMMON_OUT=true

Updated code for Lollipop by Omnirom and Paranoid

ezio: Fixed the webview apk dir and the javalib.jar
huge thanks to Marc @Grondinm

Change-Id: I52c2a53416d66dcf8cec5c9c3ab8d8013aeac24a