### PR TITLE
envsetup: Show error when supplied dir isn't present with mmm

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -922,7 +922,12 @@ function mmm()
                 case $DIR in
                   showcommands | snod | dist | incrementaljavac | *=*) ARGS="$ARGS $DIR";;
                   GET-INSTALL-PATH) GET_INSTALL_PATH=$DIR;;
-                  *) echo "No Android.mk in $DIR."; return 1;;
+                  *) if [ -d $DIR ]; then
+                         echo "No Android.mk in $DIR.";
+                     else
+                         echo "Couldn't locate the directory $DIR";
+                     fi
+                     return 1;;
                 esac
             fi
         done


### PR DESCRIPTION
When a directory isn't present with mmm, don't show
"No Android.mk present", rather show that the directory isn't present

Change-Id: I7259a60012c6f30c470daa60d5a5097d01ffc4c7
Signed-off-by: Abhinav1997 <abhinav.jhanwar.august2@gmail.com>