### PR TITLE
Revert "build: releasetools: ota: Add support for 32-64 bit upgrades"

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1859,11 +1859,8 @@ built_ota_tools :=
 
 # We can't build static executables when SANITIZE_TARGET=address
 ifeq ($(strip $(SANITIZE_TARGET)),)
-ifeq ($(TARGET_ARCH),arm64)
-	built_ota_tools += $(call intermediates-dir-for,EXECUTABLES,updater,,,32)/updater
-else
-	built_ota_tools += $(call intermediates-dir-for,EXECUTABLES,updater)/updater
-endif
+built_ota_tools += \
+    $(call intermediates-dir-for,EXECUTABLES,updater,,,$(TARGET_PREFER_32_BIT))/updater
 endif
 
 $(BUILT_TARGET_FILES_PACKAGE): PRIVATE_OTA_TOOLS := $(built_ota_tools)


### PR DESCRIPTION
* This was only required for tomato kitkat 32bit to lollipop 64bit
  migration. This is no longer a supported upgrade case, so revert
  it to be inline with AOSP.
* Users coming from stock should flash an updated 64bit recovery first

This reverts commit b89510679f72a80e973c9809d3328067eb582885.

Change-Id: Iccf37e5292c2068e9a1f8aeb370719cd9ced8c44